### PR TITLE
Draft for a .NET implementation of named tracers.

### DIFF
--- a/samples/Exporters/TestApplicationInsights.cs
+++ b/samples/Exporters/TestApplicationInsights.cs
@@ -32,7 +32,7 @@ namespace Samples
 
     internal class TestApplicationInsights
     {
-        private static readonly ITracer Tracer = Tracing.Tracer;
+        private static readonly ITracer Tracer = Tracing.TracerFactory.Create("test");
         private static readonly ITagger Tagger = Tags.Tagger;
 
         private static readonly IStatsRecorder StatsRecorder = Stats.StatsRecorder;

--- a/samples/Exporters/TestHttpClient.cs
+++ b/samples/Exporters/TestHttpClient.cs
@@ -25,13 +25,13 @@ namespace Samples
 
     internal class TestHttpClient
     {
-        private static readonly ITracer Tracer = Tracing.Tracer;
-
         internal static object Run()
         {
             Console.WriteLine("Hello World!");
 
-            using (new DependenciesCollector(new DependenciesCollectorOptions(), Tracer, Samplers.AlwaysSample))
+            var tracer = Tracing.Tracer;
+
+            using (new DependenciesCollector(new DependenciesCollectorOptions(), null, Samplers.AlwaysSample))
             {
                 var exporter = new ZipkinTraceExporter(
                     new ZipkinTraceExporterOptions()
@@ -42,7 +42,7 @@ namespace Samples
                     Tracing.SpanExporter);
                 exporter.Start();
 
-                using (Tracer.WithSpan(Tracer.SpanBuilder("incoming request").SetSampler(Samplers.AlwaysSample).StartSpan()))
+                using (tracer.WithSpan(tracer.SpanBuilder("incoming request").SetSampler(Samplers.AlwaysSample).StartSpan()))
                 {
                     using (var client = new HttpClient())
                     {

--- a/samples/Exporters/TestHttpClient.cs
+++ b/samples/Exporters/TestHttpClient.cs
@@ -29,7 +29,7 @@ namespace Samples
         {
             Console.WriteLine("Hello World!");
 
-            var tracer = Tracing.Tracer;
+            var tracer = Tracing.TracerFactory.Create("test");
 
             using (new DependenciesCollector(new DependenciesCollectorOptions(), null, Samplers.AlwaysSample))
             {

--- a/samples/Exporters/TestJaeger.cs
+++ b/samples/Exporters/TestJaeger.cs
@@ -48,9 +48,9 @@ namespace Samples
                 .Build();
             traceConfig.UpdateActiveTraceParams(newConfig);
 
-            // 3. Tracer is global singleton. You can register it via dependency injection if it exists
+            // 3. TracerFactory is global singleton. You can register it via dependency injection if it exists
             // but if not - you can use it as follows:
-            var tracer = Tracing.Tracer;
+            var tracer = Tracing.TracerFactory.Create("test");
 
             // 4. Create a scoped span. It will end automatically when using statement ends
             using (tracer.WithSpan(tracer.SpanBuilder("Main").StartSpan()))
@@ -71,8 +71,8 @@ namespace Samples
 
         private static void DoWork(int i)
         {
-            // 6. Get the global singleton Tracer object
-            var tracer = Tracing.Tracer;
+            // 6. Use the global singleton Tracer object
+            var tracer = Tracing.TracerFactory.Create("test");
 
             // 7. Start another span. If another span was already started, it'll use that span as the parent span.
             // In this example, the main method already started a span, so that'll be the parent span, and this will be

--- a/samples/Exporters/TestPrometheus.cs
+++ b/samples/Exporters/TestPrometheus.cs
@@ -29,7 +29,7 @@ namespace Samples
 
     internal class TestPrometheus
     {
-        private static readonly ITracer Tracer = Tracing.Tracer;
+        private static readonly ITracer Tracer = Tracing.TracerFactory.Create("test");
         private static readonly ITagger Tagger = Tags.Tagger;
 
         private static readonly IStatsRecorder StatsRecorder = Stats.StatsRecorder;

--- a/samples/Exporters/TestRedis.cs
+++ b/samples/Exporters/TestRedis.cs
@@ -47,9 +47,9 @@ namespace Samples
                 .Build();
             traceConfig.UpdateActiveTraceParams(newConfig);
 
-            // 3. Tracer is global singleton. You can register it via dependency injection if it exists
+            // 3. TracerFactory is global singleton. You can register it via dependency injection if it exists
             // but if not - you can use it as follows:
-            var tracer = Tracing.Tracer;
+            var tracer = Tracing.TracerFactory.Create("test");
 
             var collector = new StackExchangeRedisCallsCollector(tracer, null, Tracing.SpanExporter);
 
@@ -78,8 +78,8 @@ namespace Samples
 
         private static void DoWork(IDatabase db)
         {
-            // 6. Get the global singleton Tracer object
-            var tracer = Tracing.Tracer;
+            // 6. Get the global singleton TracerFactory object and create a Tracer.
+            var tracer = Tracing.TracerFactory.Create("test");
 
             // 7. Start another span. If another span was already started, it'll use that span as the parent span.
             // In this example, the main method already started a span, so that'll be the parent span, and this will be

--- a/samples/Exporters/TestStackdriver.cs
+++ b/samples/Exporters/TestStackdriver.cs
@@ -29,7 +29,7 @@ namespace Samples
 
     internal class TestStackdriver
     {
-        private static readonly ITracer Tracer = Tracing.Tracer;
+        private static readonly ITracer Tracer = Tracing.TracerFactory.Create("test");
         private static readonly ITagger Tagger = Tags.Tagger;
 
         private static readonly IStatsRecorder StatsRecorder = Stats.StatsRecorder;

--- a/samples/Exporters/TestZipkin.cs
+++ b/samples/Exporters/TestZipkin.cs
@@ -45,9 +45,9 @@ namespace Samples
                 .Build();
             traceConfig.UpdateActiveTraceParams(newConfig);
 
-            // 3. Tracer is global singleton. You can register it via dependency injection if it exists
+            // 3. TracerFactory is global singleton. You can register it via dependency injection if it exists
             // but if not - you can use it as follows:
-            var tracer = Tracing.Tracer;
+            var tracer = Tracing.TracerFactory.Create("test");
 
             // 4. Create a scoped span. It will end automatically when using statement ends
             using (tracer.WithSpan(tracer.SpanBuilder("Main").StartSpan()))
@@ -67,8 +67,8 @@ namespace Samples
 
         private static void DoWork(int i)
         {
-            // 6. Get the global singleton Tracer object
-            var tracer = Tracing.Tracer;
+            // 6. Get the global singleton TracerFactory object and create a Tracer.
+            var tracer = Tracing.TracerFactory.Create("test");
 
             // 7. Start another span. If another span was already started, it'll use that span as the parent span.
             // In this example, the main method already started a span, so that'll be the parent span, and this will be

--- a/samples/LoggingTracer/LoggingTracer.Demo.AspNetCore/LoggingTracerExtensions.cs
+++ b/samples/LoggingTracer/LoggingTracer.Demo.AspNetCore/LoggingTracerExtensions.cs
@@ -10,7 +10,7 @@
     static class LoggingTracerExtensions {
         internal static void AddLoggingTracer(this IServiceCollection services)
         {
-            services.AddSingleton<ITracer>(new global::LoggingTracer.LoggingTracer());
+            services.AddSingleton<ITracerFactory>(new global::LoggingTracer.LoggingTracerFactory());
 
             services.AddSingleton<ISampler>(Samplers.AlwaysSample);
             services.AddSingleton<RequestsCollectorOptions>(new RequestsCollectorOptions());

--- a/samples/LoggingTracer/LoggingTracer.Demo.ConsoleApp/Program.cs
+++ b/samples/LoggingTracer/LoggingTracer.Demo.ConsoleApp/Program.cs
@@ -6,7 +6,7 @@
 
     public class Program
     {
-        private static ITracer tracer = new LoggingTracer();
+        private static ITracer tracer = new LoggingTracer("console");
 
         public static async Task Main(string[] args)
         {

--- a/samples/LoggingTracer/LoggingTracer/LoggingTracer.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingTracer.cs
@@ -6,6 +6,13 @@
 
     public class LoggingTracer : ITracer
     {
+        private readonly string name;
+        
+        public LoggingTracer(string name)
+        {
+            this.name = name;
+        }
+        
         public ISpan CurrentSpan => CurrentSpanUtils.CurrentSpan;
 
         public IBinaryFormat BinaryFormat => new LoggingBinaryFormat();
@@ -14,30 +21,30 @@
 
         public void RecordSpanData(SpanData span)
         {
-            Logger.Log($"Tracer.RecordSpanData({span})");
+            Logger.Log($"Tracer({name}).RecordSpanData({span})");
         }
 
         public ISpanBuilder SpanBuilder(string spanName)
         {
-            Logger.Log($"Tracer.SpanBuilder({spanName})");
+            Logger.Log($"Tracer({name}).SpanBuilder({spanName})");
             return new LoggingSpanBuilder(spanName, SpanKind.Internal);
         }
 
         public ISpanBuilder SpanBuilderWithParent(string spanName, SpanKind spanKind = SpanKind.Internal, ISpan parent = null)
         {
-            Logger.Log($"Tracer.SpanBuilderWithExplicitParent({spanName}, {spanKind}, {parent})");
+            Logger.Log($"Tracer({name}).SpanBuilderWithExplicitParent({spanName}, {spanKind}, {parent})");
             return new LoggingSpanBuilder(spanName, spanKind, parent);
         }
 
         public ISpanBuilder SpanBuilderWithParentContext(string spanName, SpanKind spanKind = SpanKind.Internal, SpanContext remoteParentSpanContext = null)
         {
-            Logger.Log($"Tracer.SpanBuilderWithRemoteParent");
+            Logger.Log($"Tracer({name}).SpanBuilderWithRemoteParent");
             return new LoggingSpanBuilder(spanName, spanKind, remoteParentSpanContext);
         }
 
         public IScope WithSpan(ISpan span)
         {
-            Logger.Log($"Tracer.WithSpan");
+            Logger.Log($"Tracer({name}).WithSpan");
             return new CurrentSpanUtils.LoggingScope(span);
         }
     }

--- a/samples/LoggingTracer/LoggingTracer/LoggingTracerFactory.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingTracerFactory.cs
@@ -14,7 +14,7 @@
             // - or return Tracer from a map for the the given name.
             // - or return (new) Tracer based on a condition (e..g config) otherwise NopTracer, ... 
             // - ...
-            return new LoggingTracer();
+            return new LoggingTracer(name);
         }
     }
 }

--- a/samples/LoggingTracer/LoggingTracer/LoggingTracerFactory.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingTracerFactory.cs
@@ -1,0 +1,20 @@
+﻿namespace LoggingTracer
+{
+    using OpenTelemetry.Context;
+    using OpenTelemetry.Context.Propagation;
+    using OpenTelemetry.Trace;
+
+    public class LoggingTracerFactory : ITracerFactory
+    {
+        public ITracer Create(string name)
+        {
+            Logger.Log($"TracerFactory.Create({name})");
+            // Here
+            // - return new Tracer
+            // - or return Tracer from a map for the the given name.
+            // - or return (new) Tracer based on a condition (e..g config) otherwise NopTracer, ... 
+            // - ...
+            return new LoggingTracer();
+        }
+    }
+}

--- a/src/OpenTelemetry.Abstractions/Trace/ITracerFactory.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/ITracerFactory.cs
@@ -1,0 +1,26 @@
+﻿// <copyright file="ITracerFactory.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Trace
+{
+    /// <summary>
+    /// Create a named tracer.
+    /// </summary>
+    public interface ITracerFactory
+    {
+        ITracer Create(string name);
+    }
+}

--- a/src/OpenTelemetry.Collector.AspNetCore/RequestsCollector.cs
+++ b/src/OpenTelemetry.Collector.AspNetCore/RequestsCollector.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Collector.AspNetCore
                 {
                     { "Microsoft.AspNetCore", (t, s) => new HttpInListener(t, s) },
                 },
-                tracerFactory.Create("Microsoft.AspNetCore"),
+                tracerFactory.Create("OpenTelemetry.Collector.AspNetCore"),
                 x =>
                 {
                     ISampler s = null;

--- a/src/OpenTelemetry.Collector.AspNetCore/RequestsCollector.cs
+++ b/src/OpenTelemetry.Collector.AspNetCore/RequestsCollector.cs
@@ -34,16 +34,16 @@ namespace OpenTelemetry.Collector.AspNetCore
         /// Initializes a new instance of the <see cref="RequestsCollector"/> class.
         /// </summary>
         /// <param name="options">Configuration options for dependencies collector.</param>
-        /// <param name="tracer">Tracer to record traced with.</param>
+        /// <param name="tracerFactory">Factory for creating named Tracers.</param>
         /// <param name="sampler">Sampler to use to sample dependency calls.</param>
-        public RequestsCollector(RequestsCollectorOptions options, ITracer tracer, ISampler sampler)
+        public RequestsCollector(RequestsCollectorOptions options, ITracerFactory tracerFactory, ISampler sampler)
         {
             this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(
                 new Dictionary<string, Func<ITracer, Func<HttpRequest, ISampler>, ListenerHandler>>()
                 {
                     { "Microsoft.AspNetCore", (t, s) => new HttpInListener(t, s) },
                 },
-                tracer,
+                tracerFactory.Create("Microsoft.AspNetCore"),
                 x =>
                 {
                     ISampler s = null;

--- a/src/OpenTelemetry.Collector.Dependencies/AzureSdkDiagnosticListener.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/AzureSdkDiagnosticListener.cs
@@ -23,14 +23,11 @@ namespace OpenTelemetry.Collector.Dependencies
 
     internal class AzureSdkDiagnosticListener : ListenerHandler
     {
-        private readonly ITracer tracer;
-
         private readonly ISampler sampler;
 
-        public AzureSdkDiagnosticListener(string sourceName, ITracer tracer, ISampler sampler)
-            : base(sourceName, tracer, null)
+        public AzureSdkDiagnosticListener(string sourceName, ITracerFactory tracerFactory, ISampler sampler)
+            : base(sourceName, tracerFactory, null)
         {
-            this.tracer = tracer;
             this.sampler = sampler;
         }
 
@@ -56,7 +53,7 @@ namespace OpenTelemetry.Collector.Dependencies
                 }
             }
 
-            var spanBuilder = this.tracer.SpanBuilder(operationName)
+            var spanBuilder = this.Tracer.SpanBuilder(operationName)
                 .SetCreateChild(false)
                 .SetSampler(this.sampler);
 
@@ -66,23 +63,23 @@ namespace OpenTelemetry.Collector.Dependencies
 
             span.Status = Status.Ok;
 
-            this.tracer.WithSpan(span);
+            this.Tracer.WithSpan(span);
         }
 
         public override void OnStopActivity(Activity current, object valueValue)
         {
-            var span = this.tracer.CurrentSpan;
+            var span = this.Tracer.CurrentSpan;
             foreach (var keyValuePair in current.Tags)
             {
                 span.SetAttribute(keyValuePair.Key, keyValuePair.Value);
             }
 
-            this.tracer.CurrentSpan.End();
+            this.Tracer.CurrentSpan.End();
         }
 
         public override void OnException(Activity current, object valueValue)
         {
-            var span = this.tracer.CurrentSpan;
+            var span = this.Tracer.CurrentSpan;
 
             span.Status = Status.Unknown.WithDescription(valueValue?.ToString());
         }

--- a/src/OpenTelemetry.Collector.Dependencies/DependenciesCollector.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/DependenciesCollector.cs
@@ -34,18 +34,18 @@ namespace OpenTelemetry.Collector.Dependencies
         /// Initializes a new instance of the <see cref="DependenciesCollector"/> class.
         /// </summary>
         /// <param name="options">Configuration options for dependencies collector.</param>
-        /// <param name="tracer">Tracer to record traced with.</param>
-        /// <param name="sampler">Sampler to use to sample dependnecy calls.</param>
-        public DependenciesCollector(DependenciesCollectorOptions options, ITracer tracer, ISampler sampler)
+        /// <param name="tracerFactory">TracerFactory for creating named Tracers.</param>
+        /// <param name="sampler">Sampler to use to sample dependency calls.</param>
+        public DependenciesCollector(DependenciesCollectorOptions options, ITracerFactory tracerFactory, ISampler sampler)
         {
             this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(
-                new Dictionary<string, Func<ITracer, Func<HttpRequestMessage, ISampler>, ListenerHandler>>()
+                new Dictionary<string, Func<ITracerFactory, Func<HttpRequestMessage, ISampler>, ListenerHandler>>()
                 {
-                    { "HttpHandlerDiagnosticListener", (t, s) => new HttpHandlerDiagnosticListener(t, s) },
-                    { "Azure.Clients", (t, s) => new AzureSdkDiagnosticListener("Azure.Clients", t, sampler) },
-                    { "Azure.Pipeline", (t, s) => new AzureSdkDiagnosticListener("Azure.Pipeline", t, sampler) },
+                    { "HttpHandlerDiagnosticListener", (tf, s) => new HttpHandlerDiagnosticListener(tf, s) },
+                    { "Azure.Clients", (tf, s) => new AzureSdkDiagnosticListener("Azure.Clients", tf, sampler) },
+                    { "Azure.Pipeline", (tf, s) => new AzureSdkDiagnosticListener("Azure.Pipeline", tf, sampler) },
                 },
-                tracer,
+                tracerFactory,
                 x =>
                 {
                     ISampler s = null;

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/HttpHandlerDiagnosticListener.cs
@@ -35,8 +35,8 @@ namespace OpenTelemetry.Collector.Dependencies.Implementation
         private readonly PropertyFetcher stopRequestStatusFetcher = new PropertyFetcher("RequestTaskStatus");
         private readonly bool httpClientSupportsW3C = false;
 
-        public HttpHandlerDiagnosticListener(ITracer tracer, Func<HttpRequestMessage, ISampler> samplerFactory)
-            : base("HttpHandlerDiagnosticListener", tracer, samplerFactory)
+        public HttpHandlerDiagnosticListener(ITracerFactory tracerFactory, Func<HttpRequestMessage, ISampler> samplerFactory)
+            : base("HttpHandlerDiagnosticListener", tracerFactory, samplerFactory)
         {
             var framework = Assembly
                 .GetEntryAssembly()?

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/DiagnosticSourceSubscriber.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/DiagnosticSourceSubscriber.cs
@@ -26,18 +26,18 @@ namespace OpenTelemetry.Collector.Dependencies.Common
 
     internal class DiagnosticSourceSubscriber : IDisposable, IObserver<DiagnosticListener>
     {
-        private readonly Dictionary<string, Func<ITracer, Func<HttpRequestMessage, ISampler>, ListenerHandler>> handlers;
-        private readonly ITracer tracer;
+        private readonly Dictionary<string, Func<ITracerFactory, Func<HttpRequestMessage, ISampler>, ListenerHandler>> handlers;
+        private readonly ITracerFactory tracerFactory;
         private readonly Func<HttpRequestMessage, ISampler> sampler;
         private ConcurrentDictionary<string, DiagnosticSourceListener> subscriptions;
         private long disposed;
         private IDisposable subscription;
 
-        public DiagnosticSourceSubscriber(Dictionary<string, Func<ITracer, Func<HttpRequestMessage, ISampler>, ListenerHandler>> handlers, ITracer tracer, Func<HttpRequestMessage, ISampler> sampler)
+        public DiagnosticSourceSubscriber(Dictionary<string, Func<ITracerFactory, Func<HttpRequestMessage, ISampler>, ListenerHandler>> handlers, ITracerFactory tracerFactory, Func<HttpRequestMessage, ISampler> sampler)
         {
             this.subscriptions = new ConcurrentDictionary<string, DiagnosticSourceListener>();
             this.handlers = handlers ?? throw new ArgumentNullException(nameof(handlers));
-            this.tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
+            this.tracerFactory = tracerFactory ?? throw new ArgumentNullException(nameof(tracerFactory));
             this.sampler = sampler ?? throw new ArgumentNullException(nameof(sampler));
         }
 
@@ -57,7 +57,7 @@ namespace OpenTelemetry.Collector.Dependencies.Common
                 {
                     this.subscriptions.GetOrAdd(value.Name, name =>
                     {
-                        var dl = new DiagnosticSourceListener(this.handlers[value.Name](this.tracer, this.sampler));
+                        var dl = new DiagnosticSourceListener(this.handlers[value.Name](this.tracerFactory, this.sampler));
                         dl.Subscription = value.Subscribe(dl);
                         return dl;
                     });

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/ListenerHandler.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/ListenerHandler.cs
@@ -27,10 +27,10 @@ namespace OpenTelemetry.Collector.Dependencies.Common
 
         protected readonly Func<HttpRequestMessage, ISampler> SamplerFactory;
 
-        public ListenerHandler(string sourceName, ITracer tracer, Func<HttpRequestMessage, ISampler> samplerFactory)
+        public ListenerHandler(string sourceName, ITracerFactory tracerFactory, Func<HttpRequestMessage, ISampler> samplerFactory)
         {
             this.SourceName = sourceName;
-            this.Tracer = tracer;
+            this.Tracer = tracerFactory.Create(sourceName);
             this.SamplerFactory = samplerFactory;
         }
 

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/ListenerHandler.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/ListenerHandler.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Collector.Dependencies.Common
         public ListenerHandler(string sourceName, ITracerFactory tracerFactory, Func<HttpRequestMessage, ISampler> samplerFactory)
         {
             this.SourceName = sourceName;
-            this.Tracer = tracerFactory.Create(sourceName);
+            this.Tracer = tracerFactory.Create(nameof(OpenTelemetry.Collector.Dependencies) + "." + sourceName);
             this.SamplerFactory = samplerFactory;
         }
 

--- a/src/OpenTelemetry/Trace/Tracer.cs
+++ b/src/OpenTelemetry/Trace/Tracer.cs
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Trace
         /// </summary>
         /// <param name="startEndHandler">Start/end event handler.</param>
         /// <param name="traceConfig">Trace configuration.</param>
-        public Tracer(IStartEndHandler startEndHandler, ITraceConfig traceConfig)
+        internal Tracer(IStartEndHandler startEndHandler, ITraceConfig traceConfig)
             : this(startEndHandler, traceConfig, null, null, null)
         {
         }
@@ -59,7 +59,7 @@ namespace OpenTelemetry.Trace
         /// <param name="spanExporter">Exporter for span.</param>
         /// <param name="binaryFormat">Binary format context propagator.</param>
         /// <param name="textFormat">Text format context propagator.</param>
-        public Tracer(IStartEndHandler startEndHandler, ITraceConfig traceConfig, SpanExporter spanExporter, IBinaryFormat binaryFormat, ITextFormat textFormat)
+        internal Tracer(IStartEndHandler startEndHandler, ITraceConfig traceConfig, SpanExporter spanExporter, IBinaryFormat binaryFormat, ITextFormat textFormat)
         {
             this.spanBuilderOptions = new SpanBuilderOptions(startEndHandler, traceConfig);
             this.spanExporter = spanExporter ?? (SpanExporter)SpanExporter.Create(ExporterBufferSize, ExporterScheduleDelay);

--- a/src/OpenTelemetry/Trace/TracerFactory.cs
+++ b/src/OpenTelemetry/Trace/TracerFactory.cs
@@ -1,0 +1,33 @@
+// <copyright file="TracerFactory.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Trace
+{
+    public class TracerFactory : ITracerFactory
+    {
+        private readonly Tracer tracer;
+        
+        internal TracerFactory(Tracer tracer)
+        {
+            this.tracer = tracer;
+        }
+
+        public ITracer Create(string name)
+        {
+            return this.tracer;
+        }
+    }
+}

--- a/src/OpenTelemetry/Trace/Tracing.cs
+++ b/src/OpenTelemetry/Trace/Tracing.cs
@@ -51,10 +51,10 @@ namespace OpenTelemetry.Trace
         /// </summary>
         public static ITracerFactory TracerFactory => tracerFactory;
         
-        /// <summary>   
+/*        /// <summary>   
         /// Gets the tracer to record spans.
         /// </summary>
-        public static ITracer Tracer => tracer; // TODO: We could probably get rid of this property in favor of TracerFactory.
+        public static ITracer Tracer => tracer; // TODO: We could probably get rid of this property in favor of TracerFactory.*/
 
         /// <summary>
         /// Gets the exporter to use to upload spans.

--- a/src/OpenTelemetry/Trace/Tracing.cs
+++ b/src/OpenTelemetry/Trace/Tracing.cs
@@ -27,13 +27,12 @@ namespace OpenTelemetry.Trace
     /// </summary>
     public sealed class Tracing
     {
-        private static Tracing tracingValue = new Tracing();
+        private static TracerFactory tracerFactory;
         private static Tracer tracer;
 
         internal Tracing()
         {
             IEventQueue eventQueue = new SimpleEventQueue();
-
             TraceConfig = new Config.TraceConfig();
 
             SpanExporter = Export.SpanExporter.Create();
@@ -44,12 +43,18 @@ namespace OpenTelemetry.Trace
                     eventQueue);
 
             tracer = new Tracer(startEndHandler, TraceConfig);
+            tracerFactory = new TracerFactory(tracer);
         }
 
         /// <summary>   
+        /// Gets the factory for creating named Tracers.
+        /// </summary>
+        public static ITracerFactory TracerFactory => tracerFactory;
+        
+        /// <summary>   
         /// Gets the tracer to record spans.
         /// </summary>
-        public static ITracer Tracer => (ITracer)tracer;
+        public static ITracer Tracer => tracer; // TODO: We could probably get rid of this property in favor of TracerFactory.
 
         /// <summary>
         /// Gets the exporter to use to upload spans.

--- a/test/OpenTelemetry.Collector.Dependencies.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Collector.Dependencies.Tests/BasicTests.cs
@@ -51,6 +51,8 @@ namespace OpenTelemetry.Collector.Dependencies.Tests
         {
             var startEndHandler = new Mock<IStartEndHandler>();
             var tracer = new Tracer(startEndHandler.Object, new TraceConfig(), null, null, null);
+            var tracerFactory = new Mock<ITracerFactory>();
+            tracerFactory.Setup(m => m.Create(It.IsAny<string>())).Returns(tracer);
 
             var request = new HttpRequestMessage
             {
@@ -63,7 +65,7 @@ namespace OpenTelemetry.Collector.Dependencies.Tests
                 .Start();
             parent.TraceStateString = "k1=v1,k2=v2";
 
-            using (new DependenciesCollector(new DependenciesCollectorOptions(), tracer, Samplers.AlwaysSample))
+            using (new DependenciesCollector(new DependenciesCollectorOptions(), tracerFactory.Object, Samplers.AlwaysSample))
             using (var c = new HttpClient())
             {
                 await c.SendAsync(request);
@@ -91,6 +93,8 @@ namespace OpenTelemetry.Collector.Dependencies.Tests
         {
             var startEndHandler = new Mock<IStartEndHandler>();
             var tracer = new Tracer(startEndHandler.Object, new TraceConfig(), null, null, null);
+            var tracerFactory = new Mock<ITracerFactory>();
+            tracerFactory.Setup(m => m.Create(It.IsAny<string>())).Returns(tracer);
 
             var request = new HttpRequestMessage
             {
@@ -100,7 +104,7 @@ namespace OpenTelemetry.Collector.Dependencies.Tests
 
             request.Headers.Add("traceparent", "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01");
 
-            using (new DependenciesCollector(new DependenciesCollectorOptions(), tracer, Samplers.AlwaysSample))
+            using (new DependenciesCollector(new DependenciesCollectorOptions(), tracerFactory.Object, Samplers.AlwaysSample))
             using (var c = new HttpClient())
             {
                 await c.SendAsync(request);

--- a/test/OpenTelemetry.Collector.Dependencies.Tests/HttpClientTests.cs
+++ b/test/OpenTelemetry.Collector.Dependencies.Tests/HttpClientTests.cs
@@ -100,11 +100,13 @@ namespace OpenTelemetry.Collector.Dependencies.Tests
 
             var startEndHandler = new Mock<IStartEndHandler>();
             var tracer = new Tracer(startEndHandler.Object, new TraceConfig());
+            var tracerFactory = new Mock<ITracerFactory>();
+            tracerFactory.Setup(m => m.Create(It.IsAny<string>())).Returns(tracer);
             tc.url = NormaizeValues(tc.url, host, port);
 
             using (serverLifeTime)
             {
-                using (var dc = new DependenciesCollector(new DependenciesCollectorOptions(), tracer, Samplers.AlwaysSample))
+                using (var dc = new DependenciesCollector(new DependenciesCollectorOptions(), tracerFactory.Object, Samplers.AlwaysSample))
                 {
 
                     try

--- a/test/OpenTelemetry.Tests/Impl/Trace/TracingTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/TracingTest.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry.Trace.Test
         //      {
         //          @Override
         //        public Class<?> loadClass(String name)
-        //          {
+        //          {r
         //              throw toThrow;
         //          }
         //      });
@@ -58,7 +58,7 @@ namespace OpenTelemetry.Trace.Test
         [Fact(Skip = "need to fix the way tracer being instantiated")]
         public void DefaultTracer()
         {
-            Assert.Same(NoopTracer.Instance, Tracing.Tracer);
+            Assert.Same(NoopTracer.Instance, Tracing.TracerFactory.Create("test"));
         }
 
         [Fact(Skip = "need to fix the way tracer being instantiated")]

--- a/test/TestApp.AspNetCore.2.0/Startup.cs
+++ b/test/TestApp.AspNetCore.2.0/Startup.cs
@@ -44,7 +44,7 @@ namespace TestApp.AspNetCore._2._0
             services.AddMvc();
             services.AddSingleton<HttpClient>();
 
-            services.AddSingleton<ITracer>(Tracing.Tracer);
+            services.AddSingleton<ITracerFactory>(Tracing.TracerFactory);
             services.AddSingleton<ISampler>(Samplers.AlwaysSample);
             services.AddSingleton<RequestsCollectorOptions>(new RequestsCollectorOptions());
             services.AddSingleton<RequestsCollector>();


### PR DESCRIPTION
Add interface `ITracerFactory` and default implementation `TracerFactory`.

The sample application `LoggingTracer.Demo.AspNetCore` makes use of `TracerIFactory` by providing an implementation (`LoggingTracerFactory` ) to the ASP.NET Core DI mechanism.